### PR TITLE
Fixed a stupid bug in the C++ application

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(waveshare_channel_select LANGUAGES CXX VERSION 1.0.0)
+project(waveshare_channel_select LANGUAGES CXX VERSION 1.1.0)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/cpp/channel_select.cpp
+++ b/cpp/channel_select.cpp
@@ -147,6 +147,7 @@ int32_t parseArgs(int32_t argc, char** argv) {
         { "channel6",   no_argument,    nullptr,    '6' },
         { "channel7",   no_argument,    nullptr,    '7' },
         { "channel8",   no_argument,    nullptr,    '8' },
+        { "all",        no_argument,    nullptr,    'a' },
 
         // modifiers
         { "enable",     no_argument,    nullptr,    'e' },
@@ -156,7 +157,7 @@ int32_t parseArgs(int32_t argc, char** argv) {
         // other operations
         { "list-all",   no_argument,    nullptr,    'L' }
     };
-    constexpr const char* APP_SHORTOPTS = R"(hv12345678edrL)";
+    constexpr const char* APP_SHORTOPTS = R"(hv12345678edrLa)";
 
     int32_t optChar = -1;
 
@@ -183,6 +184,11 @@ int32_t parseArgs(int32_t argc, char** argv) {
                     break;
                 case 'L':
                     g_readAll = true;
+                    break;
+                case 'a':
+                    for (int32_t i = 0; i < 8; i++) {
+                        g_channelOptions.try_emplace(i, std::nullopt);
+                    }
                     break;
             }
         }
@@ -232,7 +238,7 @@ void printHelp() {
 Usage:
     {0:s} -h
     {0:s} -e -123       # enable channels 1, 2, and 3
-    {0:s} -d -528 -7=r  # disable channels 5, 2, and 8 and read the state of channel 7
+    {0:s} -d -528       # disable channels 5, 2, and 8 and read the state of channel 7
     {0:s} -L            # read the states of all channels
 
 Troubleshooting:
@@ -245,6 +251,7 @@ Options:
      --channel2,    -2  Look, it's the same up until -8
      ...
      --channel8,    -8  I'm sure it's self-explanatory at this point
+     --all,         -a  All channels
 
     Channel options:
      --enable,      -e  Enable channel(s)

--- a/cpp/toolchains/aarch64-toolchain.cmake
+++ b/cpp/toolchains/aarch64-toolchain.cmake
@@ -1,0 +1,18 @@
+# Set the CMake cross-compiling toolchain
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Set the path to the aarch64-linux-gnu toolchain
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+# Set the target architecture
+set(CMAKE_LIBRARY_ARCHITECTURE aarch64-linux-gnu)
+
+# Specify the linker
+set(CMAKE_LINKER aarch64-linux-gnu-ld)
+
+# Specify the necessary libraries and include directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/cpp/toolchains/armhf-toolchain.cmake
+++ b/cpp/toolchains/armhf-toolchain.cmake
@@ -1,0 +1,22 @@
+# Set the CMake cross-compiling toolchain
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+
+# Set the path to the arm-linux-gnueabihf toolchain
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+
+# Set the target architecture
+set(CMAKE_LIBRARY_ARCHITECTURE arm-linux-gnueabihf)
+
+# Set other necessary flags and options
+set(CMAKE_C_FLAGS "-march=armv7-a -mfpu=neon -mfloat-abi=hard")
+set(CMAKE_CXX_FLAGS "-march=armv7-a -mfpu=neon -mfloat-abi=hard")
+
+# Specify the linker
+set(CMAKE_LINKER arm-linux-gnueabihf-ld)
+
+# Specify the necessary libraries and include directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
This PR fixes a stupid bug in the channel_select C++ application which caused wrong outputs to be displayed when listing the state of channels.

Changes:
 - Renamed `getChannel()` to `getChannelState()`
 - The correct channel ID (1-8) is now printed when the application describes what it's doing
 - **BREAKING**: Channel specifiers now longer have optional arguments!
 - A new `-a, --all` channel specifier was added
 - Bumped up version to next minor
 - Added toolchain files for cross compilation