### PR TITLE
Feat/support rpi5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,68 @@
 This repository contains example code useful when using the WaveShare 8-channel relay module for the RaspberryPi.
 The example code provided by WaveShare is mixed up and doesn't work correctly.
 
+# C++ Application
+
+Included with this repository is a C++ application, which is now the recommended use of this repository!  
+The C++ application uses libgpiod, which is bundled in this repository. Regardless of whether or not libgpiod is found on your system,  
+the Makefile generator will always download the correct version of the library and link against it.
+
+## Building the Application
+
+Unlike in previous versions, the application has been refactored to use CMake as its Makefile generator and build system, instead of using raw compiler commands.  
+Building the application is very easy nonetheless.
+
+```sh
+# Ensure you're in the `cpp` directory!
+
+# Create build directory
+mkdir -p build && cd build
+
+# It doesn't really matter which platform you're on; because of the fallback logic, this should work on both RPi5 and older models
+
+cmake .. [-Dchannelselect_RASPI5] # Add the value in brackets if you're planning on running on RPi5.
+
+make -j$(($(nproc)-1)) # Build with nproc - 1
+```
+
+## Usage
+
+Using the app is fairly simple, and it provides a simple help text to get you started.  
+Some examples are included below:
+
+```
+waveshare_channel_select v1.1.0 - A simple application for controlling GPIO pins on modern Linux OSs on RasPi
+
+Usage:
+    waveshare_channel_select -h
+    waveshare_channel_select -e -123       # enable channels 1, 2, and 3
+    waveshare_channel_select -d -528       # disable channels 5, 2, and 8 and read the state of channel 7
+    waveshare_channel_select -L            # read the states of all channels
+
+Troubleshooting:
+    Permission denied? Is your user in the gpio group? # usermod -aG gpio <myuser>
+    Library not found? Try installing lgpiod
+
+Options:
+    Channel selection:
+     --channel1,    -1  Channel 1
+     --channel2,    -2  Look, it's the same up until -8
+     ...
+     --channel8,    -8  I'm sure it's self-explanatory at this point
+     --all,         -a  All channels
+
+    Channel options:
+     --enable,      -e  Enable channel(s)
+     --disable,     -d  Disable channel(s)
+     --read,        -r  Read the channel state
+
+    General options:
+     --list-all,    -L  List all channels and their current state
+
+     --help,        -h  Displays this text and exits
+     --version,     -v  Displays the version information and exits
+```
+
 # Bash Script
 
 Contained within this repository is a Bash script, which handles setting the GPIO pins, respective to the selected channel.
@@ -33,20 +95,3 @@ If the --help|-h arg is passed, the script will print the help text and exit.
 # Print help menu
 ./channel_select --help
 ```
-
-# C++ Application
-
-Provided with this repository is a simple sample application written in C++, providing the same functionality as the Bash script.
-
-## Building
-
-```
-g++ -std=c++17 -o channel_select cpp/channel_select.cpp
-```
-
-## Usage
-
-The C++ example provides the same features/functionality and arguments as the Bash script.<br >
-They are virtually 1:1 ports of each other.
-
-

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(waveshare_channel_select LANGUAGES CXX VERSION 1.1.0)
+project(waveshare_channel_select LANGUAGES CXX VERSION 1.2.0)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -13,6 +13,14 @@ else()
     add_compile_options(
         -O2
     )
+endif()
+
+if (DEFINED channelselect_RASPI5)
+    set(DEFAULT_GPIOCHIP "gpiochip4")
+    set(FALLBACK_GPIOCHIP "gpiochip0")
+    else()
+    set(DEFAULT_GPIOCHIP "gpiochip0")
+    set(FALLBACK_GPIOCHIP "gpiochip4")
 endif()
 
 add_compile_options(
@@ -43,4 +51,13 @@ target_link_libraries(
     gpiod::shared
     gpiodcxx::shared
     fmt
+)
+
+###
+# Define install target
+# This will install the executable to /usr/local/bin
+###
+install(
+    TARGETS channel_select
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/cpp/channel_select.in.hpp
+++ b/cpp/channel_select.in.hpp
@@ -14,6 +14,6 @@
 constexpr const char* APP_NAME = "@PROJECT_NAME@";
 constexpr const char* APP_VERS = "@PROJECT_VERSION@";
 
-constexpr const char* GPIO_CHIP = "/dev/gpiochip0"; //!< This is the chip required for controlling the relay board
-
+constexpr const char* GPIO_CHIP = "/dev/@DEFAULT_GPIOCHIP@"; //!< This is the chip required for controlling the relay board
+constexpr const char* FALLBACK_GPIO_CHIP = "/dev/@FALLBACK_GPIOCHIP@"; //!< This is the fallback chip required for controlling the relay board on a RaspberrFALLBACK
 #endif // CHANNEL_SELECT_HPP

--- a/cpp/cmake/add_libgpiod.cmake
+++ b/cpp/cmake/add_libgpiod.cmake
@@ -6,6 +6,8 @@ ExternalProject_Add(
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/submodules/libgpiod
     CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/submodules/libgpiod/autogen.sh --enable-bindings-cxx --prefix ${CMAKE_CURRENT_BINARY_DIR}/libgpiod/
 
+    UPDATE_COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR}/submodules/libgpiod && autoupdate
+
     # BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libgpiod
     BUILD_COMMAND make
 )


### PR DESCRIPTION
Added support for changes made to the RaspberryPi5 GPIO.

There is now fallback support for both older RPi models and newer RPi models.

If you're only running on RPi5, consider setting `-Dchannelselect_RPI5=<any value>` to ensure the first attempt is made against `gpiochip4`. It'll result in a minute performance benefit.